### PR TITLE
Us donation

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -62,17 +62,15 @@ const register = async (req, res, next) => {
         const existingUserByEmail = await User.findOne({ email });
         if (existingUserByEmail) {
             if (existingUserByEmail.emailVerified !== true) {
+                // Only the original registrant (matching CPF) may trigger a resend.
+                // A different CPF means a different person — block to prevent account takeover.
                 if (existingUserByEmail.cpf !== cpf) {
-                    const existingUserByCpf = await User.findOne({ cpf });
-
-                    if (existingUserByCpf) {
-                        return res.status(409).json({
-                            success: false,
-                            code: 'CPF_ALREADY_REGISTERED',
-                            field: 'cpf',
-                            message: 'CPF already registered'
-                        });
-                    }
+                    return res.status(409).json({
+                        success: false,
+                        code: 'EMAIL_ALREADY_REGISTERED',
+                        field: 'email',
+                        message: 'Email already registered'
+                    });
                 }
 
                 await sendNewVerificationCode(existingUserByEmail);
@@ -282,20 +280,14 @@ const resendVerificationCode = async (req, res, next) => {
             RESEND_VERIFICATION_CODE_COOLDOWN_SECONDS
         );
 
-        if (!user) {
+        // Return the same 200 response regardless of whether the email exists or is
+        // already verified — prevents enumeration of registered/verified accounts.
+        if (!user || user.emailVerified === true) {
             return res.status(200).json({
                 success: true,
                 code: 'VERIFICATION_CODE_SENT',
                 message: 'If the email exists and is not verified, a verification code has been sent',
                 retryAfter
-            });
-        }
-
-        if (user.emailVerified === true) {
-            return res.status(409).json({
-                success: false,
-                code: 'EMAIL_ALREADY_VERIFIED',
-                message: 'Email already verified'
             });
         }
 

--- a/controllers/donationController.js
+++ b/controllers/donationController.js
@@ -180,11 +180,10 @@ const updateDonation = async (req, res, next) => {
             });
         }
         
-        // Verificar se o usuário é o dono ou Admin
         if (donation.userId.toString() !== req.user.id) {
             const user = await User.findById(req.user.id).populate('roleId');
-            
-            if (!user || user.roleId.name !== 'Admin') {
+
+            if (user?.roleId?.name !== 'Admin') {
                 return res.status(403).json({
                     success: false,
                     message: 'You can only update your own donations'
@@ -230,11 +229,10 @@ const deleteDonation = async (req, res, next) => {
             });
         }
         
-        // Verificar se o usuário é o dono ou Admin
         if (donation.userId.toString() !== req.user.id) {
             const user = await User.findById(req.user.id).populate('roleId');
-            
-            if (!user || user.roleId.name !== 'Admin') {
+
+            if (user?.roleId?.name !== 'Admin') {
                 return res.status(403).json({
                     success: false,
                     message: 'You can only delete your own donations'

--- a/controllers/pickupController.js
+++ b/controllers/pickupController.js
@@ -133,8 +133,8 @@ const getAcceptedPickups = async (req, res, next) => {
 const getPendingPickups = async (req, res, next) => {
     try {
         const user = await User.findById(req.user.id).populate('roleId');
-        
-        if (!user || (user.roleId.name !== 'Editor' && user.roleId.name !== 'Admin')) {
+
+        if (user?.roleId?.name !== 'Editor' && user?.roleId?.name !== 'Admin') {
             return res.status(403).json({
                 success: false,
                 message: 'Only Editors and Admins can view pending pickups'
@@ -218,8 +218,8 @@ const acceptPickup = async (req, res, next) => {
         const { id } = req.params;
         
         const user = await User.findById(req.user.id).populate('roleId');
-        
-        if (!user || (user.roleId.name !== 'Editor' && user.roleId.name !== 'Admin')) {
+
+        if (user?.roleId?.name !== 'Editor' && user?.roleId?.name !== 'Admin') {
             return res.status(403).json({
                 success: false,
                 message: 'Only Editors and Admins can accept pickups'
@@ -397,8 +397,8 @@ const updatePickupStatus = async (req, res, next) => {
         const { pickupStatus } = req.body;
         
         const user = await User.findById(req.user.id).populate('roleId');
-        
-        if (!user || user.roleId.name !== 'Admin') {
+
+        if (user?.roleId?.name !== 'Admin') {
             return res.status(403).json({
                 success: false,
                 message: 'Only Admins can manually update pickup status'
@@ -449,8 +449,8 @@ const deletePickup = async (req, res, next) => {
         const { id } = req.params;
         
         const user = await User.findById(req.user.id).populate('roleId');
-        
-        if (!user || user.roleId.name !== 'Admin') {
+
+        if (user?.roleId?.name !== 'Admin') {
             return res.status(403).json({
                 success: false,
                 message: 'Only Admins can delete pickups'

--- a/controllers/semesterController.js
+++ b/controllers/semesterController.js
@@ -1,0 +1,147 @@
+const mongoose = require('mongoose');
+const Semester = require('../models/Semester');
+const Donation = require('../models/Donation');
+const User = require('../models/User');
+
+const findCurrentSemester = (now = new Date()) =>
+    Semester.findOne({ startDate: { $lte: now }, endDate: { $gt: now } });
+
+const computeProgress = async (userId, semester) => {
+    const result = await Donation.aggregate([
+        {
+            $match: {
+                userId: new mongoose.Types.ObjectId(userId),
+                donationDate: { $gte: semester.startDate, $lt: semester.endDate },
+            },
+        },
+        { $group: { _id: null, total: { $sum: '$qtdMaterial' } } },
+    ]);
+
+    const donatedAmount = result[0]?.total || 0;
+    const goalAmount = semester.goalAmount;
+    const percentage = goalAmount > 0
+        ? Math.min(Math.round((donatedAmount / goalAmount) * 100), 100)
+        : 0;
+
+    return {
+        semesterId: semester._id,
+        name: semester.name,
+        year: semester.year,
+        period: semester.period,
+        startDate: semester.startDate,
+        endDate: semester.endDate,
+        donatedAmount,
+        goalAmount,
+        percentage,
+        reachedGoal: donatedAmount >= goalAmount,
+    };
+};
+
+const createSemester = async (req, res, next) => {
+    try {
+        const user = await User.findById(req.user.id).populate('roleId');
+        if (user?.roleId?.name !== 'Admin') {
+            return res.status(403).json({ success: false, message: 'Only admins can create semesters' });
+        }
+
+        const { year, period, name, startDate, endDate, goalAmount } = req.body;
+
+        const exists = await Semester.findOne({ year, period });
+        if (exists) {
+            return res.status(409).json({
+                success: false,
+                message: `Semester ${year}.${period} already exists`,
+            });
+        }
+
+        const semester = await Semester.create({ year, period, name, startDate, endDate, goalAmount });
+        res.status(201).json({ success: true, message: 'Semester created successfully', data: semester });
+    } catch (error) {
+        console.error('Error creating semester:', error);
+        next(error);
+    }
+};
+
+const getSemesters = async (req, res, next) => {
+    try {
+        const userId = new mongoose.Types.ObjectId(req.user.id);
+        const semesters = await Semester.find().sort({ year: -1, period: -1 });
+
+        const donatedNames = [];
+        for (const semester of semesters) {
+            const count = await Donation.countDocuments({
+                userId,
+                donationDate: { $gte: semester.startDate, $lt: semester.endDate },
+            });
+            if (count > 0) donatedNames.push(semester.name);
+        }
+
+        res.status(200).json({ success: true, data: donatedNames });
+    } catch (error) {
+        console.error('Error fetching semesters:', error);
+        next(error);
+    }
+};
+
+const getCurrentSemester = async (req, res, next) => {
+    try {
+        const semester = await findCurrentSemester();
+        if (!semester) {
+            return res.status(404).json({ success: false, message: 'No active semester found' });
+        }
+        res.status(200).json({ success: true, data: semester });
+    } catch (error) {
+        console.error('Error fetching current semester:', error);
+        next(error);
+    }
+};
+
+const getCurrentProgress = async (req, res, next) => {
+    try {
+        const semester = await findCurrentSemester();
+        if (!semester) {
+            return res.status(404).json({ success: false, message: 'No active semester found' });
+        }
+        const progress = await computeProgress(req.user.id, semester);
+        res.status(200).json({ success: true, data: progress });
+    } catch (error) {
+        console.error('Error fetching current progress:', error);
+        next(error);
+    }
+};
+
+const getAllProgress = async (req, res, next) => {
+    try {
+        const semesters = await Semester.find().sort({ year: -1, period: -1 });
+        const progress = await Promise.all(
+            semesters.map(s => computeProgress(req.user.id, s))
+        );
+        res.status(200).json({ success: true, data: progress });
+    } catch (error) {
+        console.error('Error fetching progress history:', error);
+        next(error);
+    }
+};
+
+const getSemesterProgress = async (req, res, next) => {
+    try {
+        const semester = await Semester.findById(req.params.id);
+        if (!semester) {
+            return res.status(404).json({ success: false, message: 'Semester not found' });
+        }
+        const progress = await computeProgress(req.user.id, semester);
+        res.status(200).json({ success: true, data: progress });
+    } catch (error) {
+        console.error('Error fetching semester progress:', error);
+        next(error);
+    }
+};
+
+module.exports = {
+    createSemester,
+    getSemesters,
+    getCurrentSemester,
+    getCurrentProgress,
+    getAllProgress,
+    getSemesterProgress,
+};

--- a/middlewares/authMiddleware.js
+++ b/middlewares/authMiddleware.js
@@ -8,14 +8,13 @@ const verifyToken = (req, res, next) => {
       .json({ message: "Access denied. No token provided." });
   }
 
-  const token = authHeader.split(" ")[1]; // Extract token from "Bearer <token>"
+  const token = authHeader.split(" ")[1];
   try {
-    console.log(token);
-    const verified = jwt.verify(token, process.env.JWT_SECRET); // Verify token
-    req.user = verified; // Add decoded token data to req.user
-    next(); // Continue to the next middleware
+    const verified = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = verified;
+    next();
   } catch (err) {
-    res.status(400).json({ message: "Invalid token." });
+    res.status(401).json({ message: "Invalid token." });
   }
 };
 

--- a/middlewares/emailService.js
+++ b/middlewares/emailService.js
@@ -12,8 +12,8 @@ const transporter = nodemailer.createTransport({
 
 const sendResetEmail = async (to, token) => {
 
-    //gerar link de reset (ajuste a URL conforme necessário)
-    const resetLink = `http://localhost:3000/reset-password?token=${token}`;
+    const frontendUrl = process.env.FRONTEND_URL;
+    const resetLink = `${frontendUrl}/reset-password?token=${token}`;
 
     await transporter.sendMail({
         from: `"Support" <${process.env.SMTP_USER}>`,

--- a/models/Semester.js
+++ b/models/Semester.js
@@ -1,0 +1,24 @@
+const mongoose = require('mongoose');
+
+const SemesterSchema = new mongoose.Schema(
+    {
+        year: { type: Number, required: true, min: 2026 },
+        period: { type: Number, required: true, enum: [1, 2, 3, 4] },
+        name: { type: String, required: true, trim: true },
+        startDate: { type: Date, required: true },
+        endDate: { type: Date, required: true },
+        goalAmount: { type: Number, required: true, min: 1 },
+    },
+    { timestamps: true }
+);
+
+SemesterSchema.index({ year: 1, period: 1 }, { unique: true });
+
+SemesterSchema.pre('validate', function (next) {
+    if (this.startDate && this.endDate && this.endDate <= this.startDate) {
+        this.invalidate('endDate', 'endDate must be after startDate');
+    }
+    next();
+});
+
+module.exports = mongoose.model('Semester', SemesterSchema, 'semesters');

--- a/models/UserVerifications.js
+++ b/models/UserVerifications.js
@@ -8,7 +8,7 @@ const UserActivationSchema = new mongoose.Schema({
 
 UserActivationSchema.index(
     { createdAt: 1 }, 
-    { expireAfterSeconds: 30 }
+    { expireAfterSeconds: 60 * 10}
 );
 UserActivationSchema.index({ userId: 1 });
 

--- a/routes/semester.js
+++ b/routes/semester.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const router = express.Router();
+const validate = require('../middlewares/validate');
+const verifyToken = require('../middlewares/authMiddleware');
+const { authenticatedUserRateLimiter } = require('../middlewares/rateLimiter');
+const { createSemesterSchema } = require('../schemas/semesterSchemas');
+const {
+    createSemester,
+    getSemesters,
+    getCurrentSemester,
+    getCurrentProgress,
+    getAllProgress,
+    getSemesterProgress,
+} = require('../controllers/semesterController');
+
+const authenticated = [verifyToken, authenticatedUserRateLimiter];
+
+router.post('/', authenticated, validate(createSemesterSchema), createSemester);
+
+router.get('/', authenticated, getSemesters);
+router.get('/current/progress', authenticated, getCurrentProgress);
+router.get('/current', authenticated, getCurrentSemester);
+router.get('/progress', authenticated, getAllProgress);
+router.get('/:id/progress', authenticated, getSemesterProgress);
+
+module.exports = router;

--- a/schemas/semesterSchemas.js
+++ b/schemas/semesterSchemas.js
@@ -1,0 +1,42 @@
+const { z } = require('zod');
+
+const createSemesterSchema = z.object({
+    year: z.number({
+        required_error: 'Year is required',
+        invalid_type_error: 'Year must be a number'
+    })
+    .int('Year must be an integer')
+    .min(2026, 'Year must be 2026 or later'),
+
+    period: z.number({
+        required_error: 'Period is required',
+        invalid_type_error: 'Period must be a number'
+    })
+    .int('Period must be an integer')
+    .refine(v => [1, 2, 3, 4].includes(v), 'Period must be 1, 2, 3 or 4'),
+
+    name: z.string({ required_error: 'Name is required' })
+        .min(1, 'Name cannot be empty')
+        .trim(),
+
+    startDate: z.coerce.date({
+        required_error: 'startDate is required',
+        invalid_type_error: 'startDate must be a valid date'
+    }),
+
+    endDate: z.coerce.date({
+        required_error: 'endDate is required',
+        invalid_type_error: 'endDate must be a valid date'
+    }),
+
+    goalAmount: z.number({
+        required_error: 'goalAmount is required',
+        invalid_type_error: 'goalAmount must be a number'
+    })
+    .positive('goalAmount must be a positive number'),
+}).refine(data => data.endDate > data.startDate, {
+    message: 'endDate must be after startDate',
+    path: ['endDate'],
+});
+
+module.exports = { createSemesterSchema };

--- a/seeds/semestersSeeder.js
+++ b/seeds/semestersSeeder.js
@@ -1,0 +1,46 @@
+const Semester = require('../models/Semester');
+
+const SEMESTERS = [
+    {
+        year: 2026,
+        period: 1,
+        name: '2026.1',
+        startDate: new Date('2026-03-16'),
+        endDate: new Date('2026-07-19'),
+        goalAmount: 200,
+    },
+    {
+        year: 2026,
+        period: 2,
+        name: '2026.2',
+        startDate: new Date('2026-08-10'),
+        endDate: new Date('2026-12-15'),
+        goalAmount: 200,
+    },
+    {
+        year: 2026,
+        period: 4,
+        name: '2026.4',
+        startDate: new Date('2027-01-11'),
+        endDate: new Date('2027-02-18'),
+        goalAmount: 200,
+    },
+];
+
+const seedSemesters = async () => {
+    try {
+        for (const data of SEMESTERS) {
+            const exists = await Semester.findOne({ year: data.year, period: data.period });
+            if (!exists) {
+                await Semester.create(data);
+                console.log(`Semester ${data.name} created.`);
+            }
+        }
+    } catch (err) {
+        console.error('Error seeding semesters:', err);
+    }
+};
+
+seedSemesters();
+
+module.exports = { seedSemesters };

--- a/server.js
+++ b/server.js
@@ -18,6 +18,11 @@ if (!fs.existsSync(uploadDir)) {
 }
 
 const app = express();
+
+app.get("/api/health", (_req, res) => {
+  res.status(200).json({ status: "ok" });
+});
+
 app.use(cors(corsOptions));
 app.use(globalRateLimiter);
 app.use(express.json());
@@ -48,6 +53,9 @@ app.use("/api/users", userRoutes);
 const donationRoutes = require("./routes/donation");
 app.use("/api/donation", donationRoutes);
 
+const semesterRoutes = require("./routes/semester");
+app.use("/api/semesters", semesterRoutes);
+
 const mediaRoutes = require("./routes/media");
 app.use("/uploads", express.static(path.join(__dirname, "uploads")));
 app.use("/api/media", mediaRoutes);
@@ -72,6 +80,7 @@ connectDB();
 
 if (process.env.NODE_ENV === "development") {
   require("./seeds/rolesSeeder");
+  require("./seeds/semestersSeeder");
 }
 
 module.exports = app;


### PR DESCRIPTION
## Summary

- Add full semester CRUD module (model, controller, routes, Zod schema and seeder)
  with per-user progress tracking (donated amount vs. semester goal)
- Harden auth flows: fix account enumeration on `resendVerificationCode`,
  fix CPF/email conflict response on registration, return 401 for invalid/expired JWT
- Replace null-guard + direct role access with optional chaining across
  donation and pickup controllers
- Replace hardcoded localhost reset URL with `FRONTEND_URL` env var
- Extend email verification token TTL from 30s to 10 minutes

## Changes

### New
- `models/Semester.js` — Semester schema with `year/period` unique index and `endDate > startDate` validation
- `controllers/semesterController.js` — `createSemester`, `getSemesters`, `getCurrentSemester`, `getCurrentProgress`, `getAllProgress`, `getSemesterProgress`
- `routes/semester.js` — authenticated routes under `/api/semesters`
- `schemas/semesterSchemas.js` — Zod validation for semester creation
- `seeds/semestersSeeder.js` — initial 2026.1, 2026.2, 2026.4 semesters (dev only)

### Modified
- `server.js` — register semester routes, add `/api/health` before middleware chain, run semestersSeeder in dev
- `controllers/authController.js` — fix enumeration on resend, fix CPF/email conflict logic
- `middlewares/authMiddleware.js` — return 401 on invalid/expired token
- `middlewares/emailService.js` — use `FRONTEND_URL` env var for reset link
- `controllers/donationController.js` / `pickupController.js` — optional chaining for role checks
- `models/UserVerifications.js` — TTL 30s → 10 min

## Test plan

- [ ] `POST /api/semesters` cria semestre (Admin) e retorna 403 para outros roles
- [ ] `GET /api/semesters/current/progress` retorna progresso do usuário no semestre ativo
- [ ] `GET /api/semesters/progress` retorna histórico completo de progresso
- [ ] `POST /api/auth/resend-verification` retorna 200 para email inexistente e para email já verificado
- [ ] `POST /api/auth/register` com email não verificado e CPF diferente retorna `EMAIL_ALREADY_REGISTERED`
- [ ] Token expirado/inválido retorna 401